### PR TITLE
# FIX - main nav에서 icon이 이상하게 보이는 문제

### DIFF
--- a/grails-app/assets/stylesheets/application.css
+++ b/grails-app/assets/stylesheets/application.css
@@ -1474,7 +1474,7 @@ blockquote {
     border: 1px solid #ffffff;
     border-radius: 50%;
     text-align: center;
-    font-size: 11px;
+    font-size: 11px !important;
     padding-top: 4px;
     vertical-align: top;
     margin-right: 20px;


### PR DESCRIPTION
## 원인
- fontawesome의 `.fa`의 font-size가 `.nav-icon`의 font-size를 덮어씌움

## 수정사항
- `.nav-icon`의 font-size를 사용하도록 강제(!important 추가)