### PR TITLE
자바 코드 정리 및 중복코드 제거

### DIFF
--- a/src/java/com/estorm/framework/util/HttpConnection.java
+++ b/src/java/com/estorm/framework/util/HttpConnection.java
@@ -1,18 +1,37 @@
 package com.estorm.framework.util;
 
-import java.io.BufferedReader;
-import java.io.DataOutputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
 public class HttpConnection {
 
 	private final String USER_AGENT = "Mozilla/5.0";
-	
+
+	public String response(InputStream inputStream, int responseCode) throws HttpResponseException {
+		if(responseCode >= 400 && responseCode <= 511) {
+			throw new HttpResponseException(responseCode);
+		}
+
+		StringBuffer buffer = new StringBuffer();
+		BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+		String line;
+
+		try {
+			while((line = reader.readLine()) != null) {
+				buffer.append(line);
+			}
+			
+			reader.close();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+
+		return buffer.toString();
+	}
+
 	// HTTP GET request
 	public String sendGet(String url, HttpParameter params) throws Exception {
-		
 		URL obj = new URL(url + "?" + params.getParams());
 		HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 
@@ -22,24 +41,11 @@ public class HttpConnection {
 		//add request header
 		con.setRequestProperty("User-Agent", USER_AGENT);
 
-		int responseCode = con.getResponseCode();
-		
-		BufferedReader in = new BufferedReader(
-		        new InputStreamReader(con.getInputStream()));
-		String inputLine;
-		StringBuffer response = new StringBuffer();
-
-		while ((inputLine = in.readLine()) != null) {
-			response.append(inputLine);
-		}
-		in.close();
-		return response.toString();
-
+		return response(con.getInputStream(), con.getResponseCode());
 	}
 	
 	// HTTP POST request
 	public String sendPost(String url, HttpParameter params) throws Exception {
-		
 		URL obj = new URL(url);
 		HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 
@@ -57,20 +63,7 @@ public class HttpConnection {
 		wr.flush();
 		wr.close();
 
-		int responseCode = con.getResponseCode();
-		
-		BufferedReader in = new BufferedReader(
-		        new InputStreamReader(con.getInputStream()));
-		String inputLine;
-		StringBuffer response = new StringBuffer();
-
-		while ((inputLine = in.readLine()) != null) {
-			response.append(inputLine);
-		}
-		in.close();
-		return response.toString();
-
-		
+		return response(con.getInputStream(), con.getResponseCode());
 	}
 
 }

--- a/src/java/com/estorm/framework/util/HttpConnection.java
+++ b/src/java/com/estorm/framework/util/HttpConnection.java
@@ -8,7 +8,7 @@ public class HttpConnection {
 
 	private final String USER_AGENT = "Mozilla/5.0";
 
-	public String response(InputStream inputStream, int responseCode) throws HttpResponseException {
+	private String response(InputStream inputStream, int responseCode) throws HttpResponseException {
 		if(responseCode >= 400 && responseCode <= 511) {
 			throw new HttpResponseException(responseCode);
 		}
@@ -21,7 +21,7 @@ public class HttpConnection {
 			while((line = reader.readLine()) != null) {
 				buffer.append(line);
 			}
-			
+
 			reader.close();
 		} catch (IOException e) {
 			e.printStackTrace();

--- a/src/java/com/estorm/framework/util/HttpParameter.java
+++ b/src/java/com/estorm/framework/util/HttpParameter.java
@@ -4,29 +4,35 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 
 public class HttpParameter {
-	StringBuffer sb = new StringBuffer();
+
+	private StringBuffer sb = new StringBuffer();
+
 	public HttpParameter() {
 		
 	}
+
 	public HttpParameter(String name, String value) {
 		try {
-			sb.append(name+"="+ URLEncoder.encode(value, "UTF-8"));
+			sb.append(name + "=" + URLEncoder.encode(value, "UTF-8"));
 		} catch (UnsupportedEncodingException e) {
 			e.printStackTrace();
 		}
 	}
+
 	public HttpParameter add(String name, String value) {
 		if(sb.length() != 0) {
 			sb.append("&");
 		} 
 		try {
-			sb.append(name+"="+ URLEncoder.encode(value, "UTF-8"));
+			sb.append(name+ "=" + URLEncoder.encode(value, "UTF-8"));
 		} catch (UnsupportedEncodingException e) {
 			e.printStackTrace();
 		}
 		return this;
 	}
+
 	public String getParams(){
 		return sb.toString();
 	}
+
 }

--- a/src/java/com/estorm/framework/util/HttpParameter.java
+++ b/src/java/com/estorm/framework/util/HttpParameter.java
@@ -13,7 +13,7 @@ public class HttpParameter {
 
 	public HttpParameter(String name, String value) {
 		try {
-			sb.append(name + "=" + URLEncoder.encode(value, "UTF-8"));
+			sb.append(name).append("=").append(URLEncoder.encode(value, "UTF-8"));
 		} catch (UnsupportedEncodingException e) {
 			e.printStackTrace();
 		}
@@ -22,12 +22,14 @@ public class HttpParameter {
 	public HttpParameter add(String name, String value) {
 		if(sb.length() != 0) {
 			sb.append("&");
-		} 
+		}
+
 		try {
-			sb.append(name+ "=" + URLEncoder.encode(value, "UTF-8"));
+			sb.append(name).append("=").append(URLEncoder.encode(value, "UTF-8"));
 		} catch (UnsupportedEncodingException e) {
 			e.printStackTrace();
 		}
+
 		return this;
 	}
 

--- a/src/java/com/estorm/framework/util/HttpResponseException.java
+++ b/src/java/com/estorm/framework/util/HttpResponseException.java
@@ -1,0 +1,9 @@
+package com.estorm.framework.util;
+
+public class HttpResponseException extends RuntimeException {
+
+    public HttpResponseException(int responseCode) {
+        super("Response Error! err code by: " + responseCode);
+    }
+
+}

--- a/src/java/com/estorm/framework/util/OTPUtiles.java
+++ b/src/java/com/estorm/framework/util/OTPUtiles.java
@@ -24,14 +24,13 @@ public class OTPUtiles {
 		long time = System.currentTimeMillis(); 
 		SimpleDateFormat dayTime = new SimpleDateFormat(format);
 		String currentTime = dayTime.format(new Date(time));
+
 		return currentTime;
 	}
 
-
-	
-	
 	public static String[] getCreateRSAKeyPair() {
         String[] rsaKeyPair = new String[2];
+
         try {
             KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
             keyPairGenerator.initialize(2048);
@@ -55,11 +54,13 @@ public class OTPUtiles {
         } catch (Exception e) {
             e.printStackTrace();
         }
+
         return rsaKeyPair;
     }
 
 	public static String getEncryptRSAFromPublicKey(String input, String strPublicKey) {
 		String strCipher = null;
+
 		try {
 			byte[] baPublicKey = Base64.getDecoder().decode(strPublicKey);//Base64Util.getDecData(strPublicKey);
 			PublicKey publicKey = KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(baPublicKey));
@@ -70,11 +71,13 @@ public class OTPUtiles {
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
+
 		return strCipher;
 	}
 	
 	public static String getDecryptRSAFromPrivateKey(String input, String strPrivateKey) {
 		String strResult = null;
+
 		try {
 			byte[] encrypted = Base64.getDecoder().decode(input);//Base64Util.getDecData(input.getBytes());
 			byte[] baPrivateKey = Base64.getDecoder().decode(strPrivateKey);//Base64Util.getDecData(strPrivateKey.getBytes());
@@ -86,11 +89,13 @@ public class OTPUtiles {
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
+
 		return strResult;
 	}
 	
 	public static String getEncryptRSAFromPrivateKey(String input, String strPrivateKey) {
 		String strCipher = null;
+
 		try {
 			byte[] baPrivateKey = Base64.getDecoder().decode(strPrivateKey);//Base64Util.getDecData(strPrivateKey);
 			PrivateKey privateKey = KeyFactory.getInstance("RSA").generatePrivate(new PKCS8EncodedKeySpec(baPrivateKey));
@@ -101,11 +106,13 @@ public class OTPUtiles {
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
+
 		return strCipher;
 	}
 	
 	public static String getDecryptRSAFromPublicKey(String input, String strPublicKey) {
 		String strResult = null;
+
 		try {
 			byte[] encrypted = Base64.getDecoder().decode(input);//Base64Util.getDecData(input.getBytes());
 			byte[] baPublicKey = Base64.getDecoder().decode(strPublicKey);//Base64Util.getDecData(strPublicKey.getBytes());
@@ -117,6 +124,7 @@ public class OTPUtiles {
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
+
 		return strResult;
 	}
 	
@@ -124,7 +132,11 @@ public class OTPUtiles {
 		String strRet = null;
 		byte[] key = strKey.getBytes();
 		String strIV = strKey;
-		if ( key == null || strIV == null ) return null;
+
+		if ( key == null || strIV == null ) {
+			return null;
+		}
+
 		try {
 			SecretKey secureKey = new SecretKeySpec(key, "AES");
 			Cipher c = Cipher.getInstance("AES/CBC/PKCS5Padding");
@@ -134,6 +146,7 @@ public class OTPUtiles {
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
+
 		return strRet;
 	}
 	
@@ -141,7 +154,11 @@ public class OTPUtiles {
 		String strRet = null;
 		byte[] key = strKey.getBytes();
 		String strIV = strKey;
-		if ( key == null || strIV == null ) return null;
+
+		if ( key == null || strIV == null ) {
+			return null;
+		}
+
 		try {
 			SecretKey secureKey = new SecretKeySpec(key, "AES");
 			Cipher c = Cipher.getInstance("AES/CBC/PKCS5Padding");
@@ -151,6 +168,7 @@ public class OTPUtiles {
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
+
 		return strRet;
 	}
 		

--- a/src/java/com/estorm/framework/util/OTPUtiles.java
+++ b/src/java/com/estorm/framework/util/OTPUtiles.java
@@ -38,7 +38,6 @@ public class OTPUtiles {
             KeyPair keyPair = keyPairGenerator.genKeyPair();
             Key publicKey = keyPair.getPublic();
             Key privateKey = keyPair.getPrivate();
-
             
             X509EncodedKeySpec keySpecX509 = new X509EncodedKeySpec(publicKey.getEncoded());
             KeyFactory keyFactory = KeyFactory.getInstance("RSA");

--- a/src/java/com/estorm/framework/util/OTPUtiles.java
+++ b/src/java/com/estorm/framework/util/OTPUtiles.java
@@ -38,7 +38,7 @@ public class OTPUtiles {
             KeyPair keyPair = keyPairGenerator.genKeyPair();
             Key publicKey = keyPair.getPublic();
             Key privateKey = keyPair.getPrivate();
-            
+
             X509EncodedKeySpec keySpecX509 = new X509EncodedKeySpec(publicKey.getEncoded());
             KeyFactory keyFactory = KeyFactory.getInstance("RSA");
             PublicKey pubKey = keyFactory.generatePublic(keySpecX509);


### PR DESCRIPTION
1. 불필요한 공백 제거 및 공백이 필요한 부분에 적절한 공백을 넣어 가독성을 높여줬습니다.
2. com.estorm.framework.util.HttpConnection에 response 메소드를 추가하여 sendGet, sendPost 메소드에서 response 하는 부분을 메소드를 만들어 처리하였습니다.
3. HttpParameter 클래스에서 기존에 문자열 + 연산을  사용하는 부분이있었는데  이부분은 buffer의 append로 바꿔줬습니다. 이유는 문자열을 + 로 더할 시 기존 문자열을 모두 읽고 새로운 문자열에 복사하기때문에 오버헤드가 발생할 가능성이 있기 때문입니다.